### PR TITLE
Don't send data if there are no gauges and counters in the buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "main": "src/index.js",
   "author": "José Fresco <jose@keyrock.eu>",
   "license": "MIT",
-  "private": true,
   "scripts": {
     "lint": "eslint src"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,11 @@ module.exports.SignalFxCollector = function SignalFxCollector ({ basicDimensions
   }
 
   function flush () {
+    // Don't do anything if there's no data to process
+    if (!gauges.length && !counters.length) {
+      return
+    }
+
     const gaugesByMetric = groupBy(gauges, hashMetric)
     gauges = []
 


### PR DESCRIPTION
Avoid making unnecessary calls to the SignalFX API.